### PR TITLE
Fix: Unix-like systems correct path formatting

### DIFF
--- a/Runtime/LutGenerator.cs
+++ b/Runtime/LutGenerator.cs
@@ -118,7 +118,7 @@ namespace LutLight2D
 #if UNITY_EDITOR
             if (_saveIndexedLut)
             {
-                var separator = Path.DirectorySeparatorChar;
+                var slash = Path.DirectorySeparatorChar;
                 var path = $"{Path.GetDirectoryName(UnityEditor.AssetDatabase.GetAssetPath(this))}{slash}{name} Indexed.png";
                 File.WriteAllBytes(path, _lutIndexed.EncodeToPNG());
                 UnityEditor.AssetDatabase.ImportAsset(path, UnityEditor.ImportAssetOptions.ForceUpdate);


### PR DESCRIPTION
This fixes the baking of lut files on UNIX based operating systems by using the correct path seperator